### PR TITLE
Allow configuring webmentions fetched per page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ Accepted arguments:
 * `data-id` - use this container ID instead of "webmentions"
 * `data-wordcount` - truncate the reply to this many words (adding an ellipsis to
     the end of the last word)
+* `data-max-webmentions` - the maximum webmentions to retrieve and render (defaults to 20)
 
 This is a quick hack that could be a lot better.

--- a/static/webmention.js
+++ b/static/webmention.js
@@ -33,6 +33,7 @@ GitHub repo (for latest released versions, issue tracking, etc.):
     var refurl = document.currentScript.getAttribute('data-page-url') || window.location.href.replace(/#.*$/,'');
     var containerID = document.currentScript.getAttribute('data-id') || "webmentions";
     var textMaxWords = document.currentScript.getAttribute('data-wordcount');
+    var maxWebmentions = document.currentScript.getAttribute('data-max-webmentions') || '20';
 
     var reactTitle = {
         'in-reply-to': 'replied',
@@ -195,7 +196,7 @@ GitHub repo (for latest released versions, issue tracking, etc.):
 
         var pageurl = stripurl(refurl);
 
-        var apiURL = 'https://webmention.io/api/mentions.jf2?target[]=' +
+        var apiURL = 'https://webmention.io/api/mentions.jf2?per-page=' + maxWebmentions + '&target[]=' +
             encodeURIComponent('http:' + pageurl) +
             '&target[]=' + encodeURIComponent('https:' + pageurl);
 


### PR DESCRIPTION
Instead of defaulting to how many Webmention.io returns (20 at time of
writing) we should allow folks to configure it themselves via another
script parameter.