### PR TITLE
Add LibreJS license information to webmention.js

### DIFF
--- a/static/webmention.js
+++ b/static/webmention.js
@@ -94,6 +94,8 @@ A more detailed example:
 
 */
 
+// Begin LibreJS code licensing
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt
 
 (function () {
   "use strict";
@@ -451,3 +453,6 @@ A more detailed example:
     container.innerHTML = `${formattedComments}${reactions}`;
   });
 }());
+
+// End-of-file marker for LibreJS
+// @license-end


### PR DESCRIPTION
I added comments for [GNU LibreJS](https://www.gnu.org/software/librejs/free-your-javascript.html) to pick up on the licensing in the main webmention.js source file. This won't show up in the minified code, but people who care about hosting free-as-in-freedom JavaScript probably won't be hosting minified JavaScript on their site anyways (like me). Note that the reason that the initial `@license` is in a single-line comment and not a multiline comment because the current version of LibreJS does not pick up on tags in multiline comments: https://savannah.gnu.org/bugs/?59200