### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,10 @@ Security updates are only supported on the latest released version.
 ## Reporting a Vulnerability
 
 Critical vulnerabilities can be reported by emailing fluffy@beesbuzz.biz.
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in webmention.js please disclose it via [our huntr page](https://huntr.dev/repos/plaidweb/webmention.js/). Information about bounties, CVEs, response times and past reports are all there..
+
+Thank you for improving the security of webmention.js.


### PR DESCRIPTION
As requested through the platform by @fluffy-critter, this will point your security policy to [huntr.dev](https://huntr.dev/repos/plaidweb/webmention.js})